### PR TITLE
[Feat] fix build on mac silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@
 
 #-----------------------------------------------
 
+#-----------------------------------------------
+# Modify CFLAGS to ignore unused but set variable
+# For more details, plz refer to https://github.com/ctripcorp/Redis-On-Rocks/pull/255
+
+# -Wno-unused-but-set-variable: meaning do not report warning when meeting unused but set variable
+# -Wno-error: meaning do not report error when meeting warnings
+CFLAGS += -Wno-unused-but-set-variable -Wno-error
+ROCKSDB_CFLAGS = $(CFLAGS)
+#-----------------------------------------------
+
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)
 include common.mk


### PR DESCRIPTION
[Feat] fix build on mac silicon
1. Modify Makefile, working as following:
  * Step 1: preventing to report warnings when meetings unused but set variable
  * Step 2: preventing to report errors, when meeting warnings 
  ```
  #-----------------------------------------------
  # Modify CFLAGS to ignore unused but set variable
  # For more details, plz refer to https://github.com/ctripcorp/Redis-On-Rocks/pull/255
  
  # -Wno-unused-but-set-variable: meaning do not report warning when meeting unused but set variable
  # -Wno-error: meaning do not report error when meeting warnings
  CFLAGS += -Wno-unused-but-set-variable -Wno-error
  ROCKSDB_CFLAGS = $(CFLAGS)
  #-----------------------------------------------
  ```